### PR TITLE
Rebuild and publish blog on specific tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Build and publish blog
 on: 
   push:
-    branches:
-      - main
+    tags:
+      - 'publish**'
 
 permissions:
   id-token: write


### PR DESCRIPTION
A new blog post is published by rebuilding the blog. It's annoying if any time a new blog post should be published, a random PR needs be created. So publish on tag push instead.